### PR TITLE
Show transactions for a forecast entry

### DIFF
--- a/src/main/resources/static/css/AppMoney.css
+++ b/src/main/resources/static/css/AppMoney.css
@@ -116,6 +116,12 @@ table.center th, table.center td {
   border-top: 1px solid #aaa;
 }
 
+tfoot > tr.total {
+  background: #ccc;
+  font-weight: bold;
+  text-align: center;
+}
+
 .tone-down {
   color: #bbb;
 }

--- a/src/main/resources/static/js/view/transaction/List.js
+++ b/src/main/resources/static/js/view/transaction/List.js
@@ -1,0 +1,21 @@
+define(['view/Base', 'tpl!/template/transaction/list.html'],
+    function (BaseView, ListTransactionsTemplate) {
+
+  return BaseView.extend({
+    template: ListTransactionsTemplate,
+
+    initialize: function (title, totalLine, categories, transactions) {
+      this.categories = categories;
+      this.title = title;
+      this.transactions = transactions;
+      this.totalLine = totalLine;
+    },
+
+    getModalOptions: function () {
+      return {
+        content: this,
+        title: this.title
+      };
+    }
+  });
+});

--- a/src/main/resources/static/template/forecast/home.html
+++ b/src/main/resources/static/template/forecast/home.html
@@ -37,12 +37,28 @@
             </a>
           </td>
           <td><%= row.category.get('name') %></td>
-          <td>$ <%= row.spentTotalPreviousPeriod.toFixed(2) %></td>
+          <td>
+            <% if (row.spentTotalPreviousPeriod.gt(0)) { %>
+              <a href="#" data-action class="show-transactions" id="show-previous-<%= row.entry.get('id') %>">
+                $ <%= row.spentTotalPreviousPeriod.toFixed(2) %>
+              </a>
+            <% } else { %>
+              $ <%= row.spentTotalPreviousPeriod.toFixed(2) %>
+            <% } %>
+          </td>
           <td>$ <%= row.plannedTotalPreviousPeriod.toFixed(2) %></td>
           <td class="<%= row.plannedTotalPreviousPeriod.minus(row.spentTotalPreviousPeriod).gte(0) ? 'positive' : 'negative' %>">
             $ <%= (row.plannedTotalPreviousPeriod.minus(row.spentTotalPreviousPeriod).toFixed(2)) %>
           </td>
-          <td>$ <%= row.spentTotalThisPeriod.toFixed(2) %></td>
+          <td>
+            <% if (row.spentTotalThisPeriod.gt(0)) { %>
+              <a href="#" data-action class="show-transactions" id="show-actual-<%= row.entry.get('id') %>">
+                $ <%= row.spentTotalThisPeriod.toFixed(2) %>
+              </a>
+            <% } else { %>
+              $ <%= row.spentTotalThisPeriod.toFixed(2) %>
+            <% } %>
+          </td>
           <td>$ <%= row.plannedTotalThisPeriod.toFixed(2) %></td>
           <td class="<%= row.plannedTotalThisPeriod.minus(row.spentTotalThisPeriod).gte(0) ? 'positive' : 'negative' %>">
             $ <%= (row.plannedTotalThisPeriod.minus(row.spentTotalThisPeriod).toFixed(2)) %>

--- a/src/main/resources/static/template/transaction/list.html
+++ b/src/main/resources/static/template/transaction/list.html
@@ -1,0 +1,30 @@
+<table class="table table-striped table-hover">
+  <thead>
+    <tr>
+      <th>Título</th>
+      <th>Data</th>
+      <th>Valor</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%
+      var transactions = this.transactions;
+      for (var i = 0; i < transactions.length; i++) {
+    %>
+      <tr>
+        <td><%= transactions[i].get('title') %></td>
+        <td><%= transactions[i].get('happened') %></td>
+        <td>$ <%= Math.abs(transactions[i].get('value')).toFixed(2) %></td>
+      </tr>
+    <% } %>
+  </tbody>
+  <% if (this.totalLine) { %>
+    <tfoot>
+      <tr class="total">
+        <td colspan="3">
+          <%= this.totalLine %>
+        </td>
+      </tr>
+    </tfoot>
+  <% } %>
+</table>


### PR DESCRIPTION
On the forecast entries screen, when there's some amount spent on either period (actual or previous), a link will show. When clicked, it will open a modal with the transactions associated with that entry. The links as they show on the table:

<img width="1060" alt="screen shot 2017-02-25 at 7 38 08 am" src="https://cloud.githubusercontent.com/assets/143627/23331200/6a9b7da0-fb2f-11e6-821f-097a66447502.png">

The modal showing the transactions:

<img width="635" alt="screen shot 2017-02-25 at 7 49 10 am" src="https://cloud.githubusercontent.com/assets/143627/23331201/7297b32a-fb2f-11e6-8a72-1c708dc934ac.png">

