### PR TITLE
Add link to edit transaction page

### DIFF
--- a/src/main/resources/static/js/view/transaction/List.js
+++ b/src/main/resources/static/js/view/transaction/List.js
@@ -3,6 +3,9 @@ define(['view/Base', 'tpl!/template/transaction/list.html'],
 
   return BaseView.extend({
     template: ListTransactionsTemplate,
+    events: {
+      'click a' : 'hide'
+    },
 
     initialize: function (title, totalLine, categories, transactions) {
       this.categories = categories;
@@ -16,6 +19,10 @@ define(['view/Base', 'tpl!/template/transaction/list.html'],
         content: this,
         title: this.title
       };
+    },
+
+    hide: function () {
+      this.$el.parents(".modal").modal("hide");
     }
   });
 });

--- a/src/main/resources/static/template/transaction/list.html
+++ b/src/main/resources/static/template/transaction/list.html
@@ -12,7 +12,11 @@
       for (var i = 0; i < transactions.length; i++) {
     %>
       <tr>
-        <td><%= transactions[i].get('title') %></td>
+        <td>
+          <a href="/transactions/<%= transactions[i].get('id') %>">
+            <%= transactions[i].get('title') %>
+          </a>
+        </td>
         <td><%= transactions[i].get('happened') %></td>
         <td>$ <%= Math.abs(transactions[i].get('value')).toFixed(2) %></td>
       </tr>


### PR DESCRIPTION
On the show transactions modal, now there's a link that can take the user directly to the edit transaction screen:

<img width="640" alt="screen shot 2017-02-25 at 5 08 08 pm" src="https://cloud.githubusercontent.com/assets/143627/23335159/67c18482-fb7d-11e6-9620-bbf2724cd335.png">
